### PR TITLE
Bugfix/lnxdsp 544 sc57x macros

### DIFF
--- a/arch/arm/mach-sc57x/icc.c
+++ b/arch/arm/mach-sc57x/icc.c
@@ -12,7 +12,7 @@
 void platform_send_ipi_cpu(unsigned int cpu, int irq)
 {
 	BUG_ON(cpu > 2);
-	writel(cpu + TRGM_SOFT0, __io_address(REG_TRU0_MTR));
+	writel(cpu + TRGM_SOFT3, __io_address(REG_TRU0_MTR));
 }
 
 void platform_send_ipi(cpumask_t callmap, int irq)
@@ -44,8 +44,8 @@ void platform_res_manage_free_irq(uint16_t subid)
 
 void platform_ipi_init(void)
 {
-	writel(TRGM_SOFT0, __io_address(REG_TRU0_SSR71));
-	writel(TRGM_SOFT1, __io_address(REG_TRU0_SSR75));
-	writel(TRGM_SOFT2, __io_address(REG_TRU0_SSR79));
+	writel(TRGM_SOFT3, __io_address(REG_TRU0_SSR71));
+	writel(TRGM_SOFT4, __io_address(REG_TRU0_SSR75));
+	writel(TRGM_SOFT5, __io_address(REG_TRU0_SSR79));
 	writel(1, __io_address(REG_TRU0_GCTL));
 }

--- a/arch/arm/mach-sc57x/include/mach/sc57x.h
+++ b/arch/arm/mach-sc57x/include/mach/sc57x.h
@@ -57,7 +57,7 @@
 /* =========================
         WDOG1
    ========================= */
-#define REG_WDOG1_CTL               0x31009000         /* WDOG1 Control Register */
+#define REG_WDOG1_CTL               0x31008800         /* WDOG1 Control Register */
 
 /*  =========================
  *         CRC0 MMR
@@ -145,9 +145,9 @@
 /* =========================
         TRU0
    ========================= */
-#define REG_TRU0_SSR71                  0x3108A118         /* TRU0 Slave Select Register */
-#define REG_TRU0_SSR75                  0x3108A128         /* TRU0 Slave Select Register */
-#define REG_TRU0_SSR79                  0x3108A138         /* TRU0 Slave Select Register */
+#define REG_TRU0_SSR71                  0x3108A11C         /* TRU0 Slave Select Register */
+#define REG_TRU0_SSR75                  0x3108A12C         /* TRU0 Slave Select Register */
+#define REG_TRU0_SSR79                  0x3108A13C         /* TRU0 Slave Select Register */
 #define REG_TRU0_MTR                    0x3108A7E0         /* TRU0 Master Trigger Register */
 #define REG_TRU0_GCTL                   0x3108A7F4         /* TRU0 Global Control Register */
 

--- a/arch/arm/mach-sc57x/include/mach/sc57x.h
+++ b/arch/arm/mach-sc57x/include/mach/sc57x.h
@@ -154,9 +154,9 @@
 /* ===================================
        Trigger Master Definitions
    =================================== */
-#define TRGM_SOFT0                            70           /* Software-driven Trigger 0 */
-#define TRGM_SOFT1                            71           /* Software-driven Trigger 1 */
-#define TRGM_SOFT2                            72           /* Software-driven Trigger 2 */
+#define TRGM_SOFT3                            70           /* Software-driven Trigger 3 */
+#define TRGM_SOFT4                            71           /* Software-driven Trigger 4 */
+#define TRGM_SOFT5                            72           /* Software-driven Trigger 5 */
 
 /* =========================
         RCU0


### PR DESCRIPTION
Update macros for SC57x to the latest definitions from CrossCore Embedded Studio (2.8.4).
