### PR TITLE
Set SC573 max-frequency for mmc0

### DIFF
--- a/arch/arm/boot/dts/sc573-ezkit.dts
+++ b/arch/arm/boot/dts/sc573-ezkit.dts
@@ -481,6 +481,7 @@
 	bus-width = <4>;
 	pinctrl-names = "default";
 	pinctrl-0 = <&mmc0_default>;
+	max-frequency = <18750000>;
 	status = "okay";
 };
 


### PR DESCRIPTION
Linux not able to detect sdcard's partitions while trying to boot with default max-frequency. This enables ADSP-SC573 to run Linux from SDCard as rootfs.  