### PR TITLE
SC589-mini: updating flash partitions

### DIFF
--- a/arch/arm/boot/dts/sc589-mini.dts
+++ b/arch/arm/boot/dts/sc589-mini.dts
@@ -152,12 +152,12 @@
 
 		partition@3 {
 			label = "kernel (spi)";
-			reg = <0x00e0000 0x0600000>;
+			reg = <0x00e0000 0x0800000>;
 		};
 
 		partition@4 {
 			label = "root file system (spi)";
-			reg = <0x06e0000 0x0920000>;
+			reg = <0x08e0000 0x1AC0000>;
 		};
 	};
 };


### PR DESCRIPTION
Updating flash partitions in accordance with u-boot modifications for sc589-mini

After booting into a shell and logging in, rootfs is accessible from the device