### PR TITLE
SC5xx: Fix non-DMA operation in the adi_uart4 driver

### DIFF
--- a/arch/arm/boot/dts/sc57x.dtsi
+++ b/arch/arm/boot/dts/sc57x.dtsi
@@ -270,6 +270,7 @@
 			dmas = <&dma_cluster2 20>, <&dma_cluster2 21>;
 			dma-names = "tx", "rx";
 			interrupt-parent = <&gic>;
+			interrupt-names = "tx", "rx", "status";
 			interrupts = <GIC_SPI 106 IRQ_TYPE_LEVEL_HIGH>,
 				     <GIC_SPI 107 IRQ_TYPE_LEVEL_HIGH>,
 				     <GIC_SPI 108 IRQ_TYPE_LEVEL_HIGH>;
@@ -284,6 +285,7 @@
 			dmas = <&dma_cluster2 34>, <&dma_cluster2 35>;
 			dma-names = "tx", "rx";
 			interrupt-parent = <&gic>;
+			interrupt-names = "tx", "rx", "status";
 			interrupts = <GIC_SPI 109 IRQ_TYPE_LEVEL_HIGH>,
 				     <GIC_SPI 110 IRQ_TYPE_LEVEL_HIGH>,
 				     <GIC_SPI 111 IRQ_TYPE_LEVEL_HIGH>;
@@ -298,6 +300,7 @@
 			dmas = <&dma_cluster2 37>, <&dma_cluster2 38>;
 			dma-names = "tx", "rx";
 			interrupt-parent = <&gic>;
+			interrupt-names = "tx", "rx", "status";
 			interrupts = <GIC_SPI 112 IRQ_TYPE_LEVEL_HIGH>,
 				     <GIC_SPI 113 IRQ_TYPE_LEVEL_HIGH>,
 				     <GIC_SPI 114 IRQ_TYPE_LEVEL_HIGH>;

--- a/arch/arm/boot/dts/sc58x.dtsi
+++ b/arch/arm/boot/dts/sc58x.dtsi
@@ -280,6 +280,7 @@
 			dmas = <&dma_cluster2 20>, <&dma_cluster2 21>;
 			dma-names = "tx", "rx";
 			interrupt-parent = <&gic>;
+			interrupt-names = "tx", "rx", "status";
 			interrupts = <GIC_SPI 114 IRQ_TYPE_LEVEL_HIGH>,
 				     <GIC_SPI 115 IRQ_TYPE_LEVEL_HIGH>,
 				     <GIC_SPI 116 IRQ_TYPE_LEVEL_HIGH>;
@@ -294,6 +295,7 @@
 			dmas = <&dma_cluster2 34>, <&dma_cluster2 35>;
 			dma-names = "tx", "rx";
 			interrupt-parent = <&gic>;
+			interrupt-names = "tx", "rx", "status";
 			interrupts = <GIC_SPI 117 IRQ_TYPE_LEVEL_HIGH>,
 				     <GIC_SPI 118 IRQ_TYPE_LEVEL_HIGH>,
 				     <GIC_SPI 119 IRQ_TYPE_LEVEL_HIGH>;
@@ -308,6 +310,7 @@
 			dmas = <&dma_cluster2 37>, <&dma_cluster2 38>;
 			dma-names = "tx", "rx";
 			interrupt-parent = <&gic>;
+			interrupt-names = "tx", "rx", "status";
 			interrupts = <GIC_SPI 120 IRQ_TYPE_LEVEL_HIGH>,
 				     <GIC_SPI 121 IRQ_TYPE_LEVEL_HIGH>,
 				     <GIC_SPI 122 IRQ_TYPE_LEVEL_HIGH>;

--- a/arch/arm/boot/dts/sc59x.dtsi
+++ b/arch/arm/boot/dts/sc59x.dtsi
@@ -285,6 +285,7 @@
 			dmas = <&dma_cluster2 20>, <&dma_cluster2 21>;
 			dma-names = "tx", "rx";
 			interrupt-parent = <&gic>;
+			interrupt-names = "tx", "rx", "status";
 			interrupts = <GIC_SPI 138 IRQ_TYPE_LEVEL_HIGH>,
 				     <GIC_SPI 139 IRQ_TYPE_LEVEL_HIGH>,
 				     <GIC_SPI 140 IRQ_TYPE_LEVEL_HIGH>;
@@ -299,6 +300,7 @@
 			dmas = <&dma_cluster2 34>, <&dma_cluster2 35>;
 			dma-names = "tx", "rx";
 			interrupt-parent = <&gic>;
+			interrupt-names = "tx", "rx", "status";
 			interrupts = <GIC_SPI 141 IRQ_TYPE_LEVEL_HIGH>,
 				     <GIC_SPI 142 IRQ_TYPE_LEVEL_HIGH>,
 				     <GIC_SPI 143 IRQ_TYPE_LEVEL_HIGH>;
@@ -313,6 +315,7 @@
 			dmas = <&dma_cluster2 37>, <&dma_cluster2 38>;
 			dma-names = "tx", "rx";
 			interrupt-parent = <&gic>;
+			interrupt-names = "tx", "rx", "status";
 			interrupts = <GIC_SPI 144 IRQ_TYPE_LEVEL_HIGH>,
 				     <GIC_SPI 145 IRQ_TYPE_LEVEL_HIGH>,
 				     <GIC_SPI 146 IRQ_TYPE_LEVEL_HIGH>;

--- a/arch/arm64/boot/dts/adi/sc59x-64.dtsi
+++ b/arch/arm64/boot/dts/adi/sc59x-64.dtsi
@@ -297,7 +297,7 @@
 			interrupt-names = "tx", "rx", "status";
 			interrupts = <GIC_SPI 138 IRQ_TYPE_LEVEL_HIGH>,
 				     <GIC_SPI 139 IRQ_TYPE_LEVEL_HIGH>,
-						 <GIC_SPI 140 IRQ_TYPE_LEVEL_HIGH>;
+				     <GIC_SPI 140 IRQ_TYPE_LEVEL_HIGH>;
 			adi,use-edbo;
 			status = "disabled";
 		};

--- a/drivers/tty/serial/adi_uart4.c
+++ b/drivers/tty/serial/adi_uart4.c
@@ -1103,7 +1103,11 @@ static int adi_uart4_serial_probe(struct platform_device *pdev)
 
 	uartid = of_alias_get_id(np, "serial");
 	tx_dma_channel = dma_request_chan(dev, "tx");
+	if (IS_ERR(tx_dma_channel))
+		tx_dma_channel = NULL;
 	rx_dma_channel = dma_request_chan(dev, "rx");
+	if (IS_ERR(rx_dma_channel))
+		rx_dma_channel = NULL;
 
 	if (uartid < 0) {
 		dev_err(&pdev->dev, "failed to get alias/pdev id, errno %d\n",


### PR DESCRIPTION
When using the driver in non-DMA mode, the following issues were found:

    drivers: tty: serial: adi_uart4: Fix non-dma mode crash

    dma_request_chan() returns an ERRPTR on failure, not a null pointer.
    This will result in a crash when the driver operates without DMA.


    dts: Analog SC5xx chips: Add missing uart interrupt names

    When configured to operate in non-dma mode, recent adi_uart4 driver
    changes require the interrupts to be named. Copy all these missing
    names from the sc598 to all the other platforms.