### PR TITLE
Adding adi spidev entry

### DIFF
--- a/arch/arm/boot/dts/sc594-som.dtsi
+++ b/arch/arm/boot/dts/sc594-som.dtsi
@@ -140,30 +140,30 @@
 		reg = <0>;
 	};
 
-	ad7879_touchscreen@1 {
-		#address-cells = <1>;
-		#size-cells = <1>;
-		compatible = "adi,ad7879";
-		spi-max-frequency = <5000000>;
-		reg = <1>;
-		gpio = <88>;
-		gpio-controller;
-		spi-cpha;
-		spi-cpol;
-		touchscreen-max-pressure = <10000>;
-		adi,resistance-plate-x = <620>;
-		adi,first-conversion-delay = /bits/ 8 <3>;
-		adi,acquisition-time = /bits/ 8 <1>;
-		adi,median-filter-size = /bits/ 8 <2>;
-		adi,averaging = /bits/ 8 <1>;
-		adi,conversion-interval = /bits/ 8 <255>;
-	};
+//	ad7879_touchscreen@1 {
+//		#address-cells = <1>;
+//		#size-cells = <1>;
+//		compatible = "adi,ad7879";
+//		spi-max-frequency = <5000000>;
+//		reg = <1>;
+//		gpio = <88>;
+//		gpio-controller;
+//		spi-cpha;
+//		spi-cpol;
+//		touchscreen-max-pressure = <10000>;
+//		adi,resistance-plate-x = <620>;
+//		adi,first-conversion-delay = /bits/ 8 <3>;
+//		adi,acquisition-time = /bits/ 8 <1>;
+//		adi,median-filter-size = /bits/ 8 <2>;
+//		adi,averaging = /bits/ 8 <1>;
+//		adi,conversion-interval = /bits/ 8 <255>;
+//	};
 };
 
 &spi1 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&spi1_default>;
-	status = "okay";
+	status = "disabled";
 
 	cs-gpios = <&gpa 13 GPIO_ACTIVE_LOW>;
 

--- a/drivers/spi/spidev.c
+++ b/drivers/spi/spidev.c
@@ -691,6 +691,7 @@ static const struct spi_device_id spidev_spi_ids[] = {
 	{ .name = "m53cpld" },
 	{ .name = "spi-petra" },
 	{ .name = "spi-authenta" },
+	{ .name = "generic-spidev"},
 	{},
 };
 MODULE_DEVICE_TABLE(spi, spidev_spi_ids);

--- a/include/dt-bindings/pinctrl/adi-adsp-sru.h
+++ b/include/dt-bindings/pinctrl/adi-adsp-sru.h
@@ -386,7 +386,6 @@
 #define SPT3_AD1_O_D              367     //GROUP_D
 #define SPT3_BD0_O_D              368     //GROUP_D
 #define SPT3_BD1_O_D              369     //GROUP_D
-#define MLB0_CLKOUT_O_D           370     //GROUP_D
 #define SPDIF0_TX_BLKSTART_O_D    371     //GROUP_D
 #define SPT3_ACLK_O_D             372     //GROUP_D
 #define SPT3_BCLK_O_D             373     //GROUP_D


### PR DESCRIPTION
Resolving kernel spi errors (boot)
```
SPI driver spidev has no spi_device_id for adi,generic-spidev
of_dma_request_slave_channel: dma-names property of node '/scb/spi@0x3102f000' missing or empty
of_dma_request_slave_channel: dma-names property of node '/scb/spi@0x3102f000' missing or empty
```
Resolving dts warnings (spi0 is disabled by default, so commenting this out does not change the current functioning)
```
arch/arm/boot/dts/sc594-som.dtsi:149.3-15: Warning (gpios_property): /scb/spi@0x3102e000/ad7879_touchscreen@1:gpio: cell 0 is not a phandle reference
arch/arm/boot/dts/sc594-som.dtsi:149.3-15: Warning (gpios_property): /scb/spi@0x3102e000/ad7879_touchscreen@1:gpio: Could not get phandle node for (cell 0)
arch/arm/boot/dts/sc594-som.dtsi:149.3-15: Warning (gpios_property): /scb/spi@0x3102e000/ad7879_touchscreen@1:gpio: cell 0 is not a phandle reference
arch/arm/boot/dts/sc594-som.dtsi:149.3-15: Warning (gpios_property): /scb/spi@0x3102e000/ad7879_touchscreen@1:gpio: Could not get phandle node for (cell 0)
```