### PR TITLE
SC594: Hotfix for SC594 L3 DDR memory overlap

### DIFF
--- a/arch/arm/boot/dts/sc594-som.dtsi
+++ b/arch/arm/boot/dts/sc594-som.dtsi
@@ -21,7 +21,7 @@
 
 	chosen {
 		stdout-path = &uart1;
-		bootargs = "root=/dev/mtdblock4 rw rootfstype=jffs2 earlyprintk=serial,uart0,115200 console=ttySC0,115200 vmalloc=512M";
+		bootargs = "root=/dev/mtdblock4 rw rootfstype=jffs2 earlyprintk=serial,uart0,115200 console=ttySC0,115200 vmalloc=512M mem=512M";
 	};
 
 	aliases {
@@ -29,7 +29,7 @@
 
 	memory@80000000 { /*8 Gbit DDR*/
 		device_type = "memory";
-		reg = <0x80000000 0x40000000>;
+		reg = <0xa0000000 0x20000000>;
 	};
 
 	reserved-memory {

--- a/arch/arm/mach-sc5xx/Makefile.boot
+++ b/arch/arm/mach-sc5xx/Makefile.boot
@@ -21,6 +21,6 @@ params_phys-y	:= 0xC2000100
 endif
 
 ifeq ($(CONFIG_MACH_SC594_SOM),y)
-zreladdr-y      += 0x82008000
-params_phys-y   := 0x82000100
+zreladdr-y      += 0xA0008000
+params_phys-y   := 0xA0000100
 endif

--- a/drivers/soc/adi/mach-sc59x/Makefile.boot
+++ b/drivers/soc/adi/mach-sc59x/Makefile.boot
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)-or-later
 
 ifeq ($(CONFIG_MACH_SC594_SOM),y)
-zreladdr-y      += 0x82008000
-params_phys-y   := 0x82000100
+zreladdr-y	+= 0xA0008000
+params_phys-y	:= 0xA0000100
 else
 zreladdr-y	+= 0x80008000
 params_phys-y	:= 0x80000100


### PR DESCRIPTION
Resizing accessible memory range for ARM on sc594 such that it does not overlap with SHARC allocated address space