### PR TITLE
SC594: Hotfix for SC594 L3 DDR memory overlap

### DIFF
--- a/arch/arm/boot/dts/sc594-som-ezkit.dts
+++ b/arch/arm/boot/dts/sc594-som-ezkit.dts
@@ -22,9 +22,9 @@
 	aliases {
 	};
 
-	memory@C3000000 {
+	memory@80000000 {
 		device_type = "memory";
-		reg = <0xC3000000 0xF000000>;
+		reg = <0xa0000000 0x20000000>;
 	};
 
 #ifdef IGNORE_FOR_NOW

--- a/arch/arm/mach-sc5xx/Makefile.boot
+++ b/arch/arm/mach-sc5xx/Makefile.boot
@@ -19,6 +19,6 @@ params_phys-y	:= 0xC2000100
 endif
 
 ifeq ($(CONFIG_MACH_SC594_SOM_EZKIT),y)
-zreladdr-y      += 0x82008000
-params_phys-y   := 0x82000100
+zreladdr-y      += 0xA0008000
+params_phys-y   := 0xA0000100
 endif

--- a/drivers/soc/adi/mach-sc59x/Makefile.boot
+++ b/drivers/soc/adi/mach-sc59x/Makefile.boot
@@ -1,6 +1,6 @@
 ifeq ($(CONFIG_MACH_SC594_SOM_EZKIT),y)
-zreladdr-y      += 0x82008000
-params_phys-y   := 0x82000100
+zreladdr-y      += 0xA0008000
+params_phys-y   := 0xA0000100
 else
 zreladdr-y	+= 0x80008000
 params_phys-y	:= 0x80000100


### PR DESCRIPTION
Resizing accessible memory range for ARM on sc594 such that it does not overlap with SHARC allocated address space