### PR TITLE
Increase SPI rootfs partition size to maximum available

### DIFF
--- a/arch/arm/boot/dts/sc589-mini.dts
+++ b/arch/arm/boot/dts/sc589-mini.dts
@@ -157,7 +157,7 @@
 
 		partition@4 {
 			label = "root file system (spi)";
-			reg = <0x08e0000 0x1AC0000>;
+			reg = <0x08e0000 0x3720000>;
 		};
 	};
 };


### PR DESCRIPTION
More space for rootfs on SC589-mini